### PR TITLE
Configure the environment in the Build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    environment: Development
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,3 +77,11 @@ Directories:
     1. `flake8` - for linting
     1. `isort` - for formatting imports
     1. `coverage` - for coverage reports
+
+## DockerHub Image artifactory
+Link: https://hub.docker.com/repository/docker/ps332/elevator-system-django/general
+### Image, Tag Nomenclature
+- Image Name: Name of repository (in lowercase)
+- Tag Name: Name of reference (branch/tag)_(branch-name/tag-name)
+    - eg: for branch - `feat/add-docker-build-job` Image and tag would be: ```ps332/elevator-system-django:refs_heads_feat_add-docker-build-job```
+


### PR DESCRIPTION
This is to prevent misuse of build job in workflow as in dockerhub free plan only limited amount of image push is required in a day